### PR TITLE
Fix code scanning alert #3: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesController.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesController.java
@@ -239,9 +239,9 @@ public class ChallengesController {
 
   private String generateCode(ChallengeUI challenge) {
     SecretKeySpec secretKeySpec =
-        new SecretKeySpec(ctfKey.getBytes(StandardCharsets.UTF_8), "HmacSHA1");
+        new SecretKeySpec(ctfKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     try {
-      Mac mac = Mac.getInstance("HmacSHA1");
+      Mac mac = Mac.getInstance("HmacSHA256");
       mac.init(secretKeySpec);
       byte[] result = mac.doFinal(challenge.getName().getBytes(StandardCharsets.UTF_8));
       return new String(Hex.encode(result));


### PR DESCRIPTION
Fixes [https://github.com/turbo/ws-test-1/security/code-scanning/3](https://github.com/turbo/ws-test-1/security/code-scanning/3)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
